### PR TITLE
nodejs package in debian wheezy-backports

### DIFF
--- a/doc/update/7.8-to-7.9.md
+++ b/doc/update/7.8-to-7.9.md
@@ -43,6 +43,8 @@ sudo -u git -H git checkout v2.6.0
 ### 4. Install libs, migrations, etc.
 
 ```bash
+# If on debian wheezy, you'll need to add backports to your apt sources.
+# See http://backports.debian.org/Instructions/
 sudo apt-get install nodejs
 
 cd /home/git/gitlab


### PR DESCRIPTION
If running gitlab on debian wheezy, you'll need to add wheezy backports to /etc/apt/sources.list (or another .list file, see http://backports.debian.org/Instructions/) before you'll be able to install the nodejs package.

[ci skip]
